### PR TITLE
Trigger foreground event when an activity is started on first launch

### DIFF
--- a/library/src/main/java/com/jenzz/appstate/internal/AppStateRecognizer.java
+++ b/library/src/main/java/com/jenzz/appstate/internal/AppStateRecognizer.java
@@ -62,7 +62,8 @@ public final class AppStateRecognizer {
     @Override
     public void onActivityStarted(Activity activity) {
       if (isFirstLaunch.compareAndSet(true, false)) {
-        appState = FOREGROUND;
+        onAppDidEnterForeground();
+        return;
       }
 
       if (appState == BACKGROUND) {

--- a/library/src/test/java/com/jenzz/appstate/internal/AppStateRecognizerTest.java
+++ b/library/src/test/java/com/jenzz/appstate/internal/AppStateRecognizerTest.java
@@ -1,21 +1,29 @@
 package com.jenzz.appstate.internal;
 
+import android.app.Activity;
 import android.app.Application;
 import android.app.Application.ActivityLifecycleCallbacks;
 import android.content.ComponentCallbacks2;
+import com.jenzz.appstate.AppStateListener;
 import com.jenzz.appstate.dummies.DummyAppStateListener;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
 import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 public class AppStateRecognizerTest {
 
   @Mock Application mockApplication;
+  @Mock AppStateListener mockAppStateListener;
+
+  @Captor ArgumentCaptor<ActivityLifecycleCallbacks> activityCallbacksCaptor;
 
   private final AppStateRecognizer appStateRecognizer = new AppStateRecognizer();
 
@@ -43,5 +51,28 @@ public class AppStateRecognizerTest {
   @Test
   public void doesNotReturnNullAppStateByDefault() {
     assertThat(appStateRecognizer.getAppState()).isNotNull();
+  }
+
+  @Test
+  public void emitsForegroundIfActivityStartsOnFirstLaunch() {
+    appStateRecognizer.start(mockApplication, mockAppStateListener);
+    verify(mockApplication).registerActivityLifecycleCallbacks(activityCallbacksCaptor.capture());
+
+    activityCallbacksCaptor.getValue().onActivityStarted(new Activity());
+
+    verify(mockAppStateListener).onAppDidEnterForeground();
+  }
+
+  @Test
+  public void doesNotEmitForegroundIfActivityStartsOnSuccessiveLaunches() {
+    appStateRecognizer.start(mockApplication, mockAppStateListener);
+    verify(mockApplication).registerActivityLifecycleCallbacks(activityCallbacksCaptor.capture());
+    final ActivityLifecycleCallbacks lifecycleCallbacks = activityCallbacksCaptor.getValue();
+    
+    lifecycleCallbacks.onActivityStarted(new Activity());
+    lifecycleCallbacks.onActivityStarted(new Activity());
+    lifecycleCallbacks.onActivityStarted(new Activity());
+
+    verify(mockAppStateListener, times(1)).onAppDidEnterForeground();
   }
 }


### PR DESCRIPTION
Fixes https://github.com/jenzz/RxAppState/issues/1 by triggering the foreground event when an `Activity` is started at first launch.

See https://github.com/jenzz/RxAppState/issues/1#issuecomment-253598698 for motivation and context.