### PR TITLE
Avoid triggering background event when the screen turns off and the app was already on background

### DIFF
--- a/library/src/main/java/com/jenzz/appstate/internal/AppStateRecognizer.java
+++ b/library/src/main/java/com/jenzz/appstate/internal/AppStateRecognizer.java
@@ -86,7 +86,9 @@ public final class AppStateRecognizer {
 
     @Override
     public void onReceive(Context context, Intent intent) {
-      onAppDidEnterBackground();
+      if (appState == FOREGROUND) {
+        onAppDidEnterBackground();
+      }
     }
   }
 }

--- a/library/src/main/java/com/jenzz/appstate/internal/AppStateRecognizer.java
+++ b/library/src/main/java/com/jenzz/appstate/internal/AppStateRecognizer.java
@@ -40,6 +40,7 @@ public final class AppStateRecognizer {
   public void stop(@NonNull Application app) {
     app.unregisterActivityLifecycleCallbacks(activityStartedCallback);
     app.unregisterComponentCallbacks(uiHiddenCallback);
+    app.unregisterReceiver(screenOffBroadcastReceiver);
   }
 
   @NonNull

--- a/library/src/test/java/com/jenzz/appstate/internal/AppStateRecognizerTest.java
+++ b/library/src/test/java/com/jenzz/appstate/internal/AppStateRecognizerTest.java
@@ -3,19 +3,30 @@ package com.jenzz.appstate.internal;
 import android.app.Application;
 import android.app.Application.ActivityLifecycleCallbacks;
 import android.content.ComponentCallbacks2;
+import android.content.Intent;
+import com.jenzz.appstate.AppStateListener;
 import com.jenzz.appstate.dummies.DummyAppStateListener;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 
+import static android.content.ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN;
+import static android.content.Intent.ACTION_SCREEN_OFF;
 import static org.assertj.core.api.Java6Assertions.assertThat;
 import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 public class AppStateRecognizerTest {
 
   @Mock Application mockApplication;
+  @Mock AppStateListener mockAppStateListener;
+
+  @Captor ArgumentCaptor<ComponentCallbacks2> componentCallbacksCaptor;
 
   private final AppStateRecognizer appStateRecognizer = new AppStateRecognizer();
 
@@ -43,5 +54,26 @@ public class AppStateRecognizerTest {
   @Test
   public void doesNotReturnNullAppStateByDefault() {
     assertThat(appStateRecognizer.getAppState()).isNotNull();
+  }
+
+  @Test
+  public void doesNotEmitBackgroundWhenScreenOffAndAppMonitoringJustStarted() {
+    appStateRecognizer.start(mockApplication, mockAppStateListener);
+
+    mockApplication.sendBroadcast(new Intent(ACTION_SCREEN_OFF));
+
+    verify(mockAppStateListener, never()).onAppDidEnterBackground();
+  }
+
+  @Test
+  public void doesNotEmitBackgroundWhenScreenOffAndAppAlreadyOnBackground() {
+    appStateRecognizer.start(mockApplication, mockAppStateListener);
+    verify(mockApplication).registerComponentCallbacks(componentCallbacksCaptor.capture());
+    final ComponentCallbacks2 componentCallbacks = componentCallbacksCaptor.getValue();
+
+    componentCallbacks.onTrimMemory(TRIM_MEMORY_UI_HIDDEN);
+    mockApplication.sendBroadcast(new Intent(ACTION_SCREEN_OFF));
+
+    verify(mockAppStateListener, times(1)).onAppDidEnterBackground();
   }
 }


### PR DESCRIPTION
Fixes https://github.com/jenzz/RxAppState/issues/8

My solution is just checking that the app is on foreground before calling `onAppDidEnterBackground()` when it receives the screen off broadcast.

There are other possible solutions like registering for the screen off `Intent` only while the app is on foreground, but I think it may me a bit overkilling.

Also I unregister the screen off receiver when calling `stop()` just for the sake of symmetry.

Finally, regarding tests, this can be tested at `RxAppState` level instead of the recognizer, just as you do for the `onTrimMemory` scenario. I thought this tests belonged here better, but let me know if you prefer otherwise.